### PR TITLE
Add withTokenBucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `withTokenBucket` helper function, which executes a callback with an appropriate
+  delay according to a provided `HierarchicalTokenBucket`.
+
 ## 0.1.0 - 2022-05-05
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,8 @@ export class HierarchicalTokenBucket {
    *
    * await fetch('https://my.target.host/that/supports/throttling')
    * ```
+   * See also withTokenBucket, which implements this functionality
+   * for a callback.
    *
    * @returns time to wait in milliseconds
    */
@@ -155,4 +157,27 @@ export class HierarchicalTokenBucket {
 
     return Math.max(minTimeToWait, timeForThisToWait, timeForParentToWait);
   }
+}
+
+async function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+/**
+ * Executes the callback function after a delay according to the 
+ * wait time returned by the tokenBucket.
+ * 
+ * Executes immediately if the tokenBucket indicates a wait time of 0.
+ *
+ * @returns Promise<T> according to the callback
+ */
+ export async function withTokenBucket<T>(
+  tokenBucket: HierarchicalTokenBucket,
+  cb: () => Promise<T>,
+): Promise<T> {
+  const timeToWaitInMs = tokenBucket.take();
+  await sleep(timeToWaitInMs);
+  return await cb();
 }


### PR DESCRIPTION
Also, what would you think of doing something like:
```
    if (!(options.maximumCapacity)) {
      options.maximumCapacity = options.parent.maximumCapacity;
    }
    if (!(options.refillRate)) {
     options.refillRate = options.parent.refillRate;
    }
```
That would let me do `.child({})` in the vast majority of cases in the client files and make it easier to read, at the cost of not making the usage quite as explicit.