### PR TITLE
Fix dist types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.2.0",
   "description": "A simple hierarchical token bucket",
   "main": "dist/index.js",
-  "types": "dist/index.ts",
+  "types": "dist/index.d.ts",
   "license": "MIT",
   "files": [
     "dist/",


### PR DESCRIPTION
The `types` file declared in `package.json` was incorrect, which prevented consumers from using the package's exported types.